### PR TITLE
Make initscene use highest aframe-registry version.

### DIFF
--- a/lib/initscene.js
+++ b/lib/initscene.js
@@ -8,7 +8,7 @@ var nunjucks = require('nunjucks');
 var path = require('path');
 var slug = require('slug');
 
-var aframeVersion = '0.4.0' || Object.keys(require('aframe-registry')).sort().reverse()[0];
+var aframeVersion = Object.keys(require('aframe-registry')).sort().reverse()[0];
 
 function initscene () {
   console.log('Initializing A-Frame scene');


### PR DESCRIPTION
Removed the hardcoded `0.4.0` version for the `angle initscene` command. Now it uses the latest version from the `aframe-registry` package.